### PR TITLE
Localization

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,7 @@ android {
     dependencies {
         implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:8.4.0"
         implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.7.0"
+        implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.11.0'		
     }
     compileOptions {
         sourceCompatibility 1.8

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -117,6 +117,7 @@ final class MapboxMapController
   private final String styleStringInitial;
   private LocationComponent locationComponent = null;
   private LocationEngine locationEngine = null;
+  private LocalizationPlugin localizationPlugin;
 
   MapboxMapController(
     int id,
@@ -321,6 +322,8 @@ final class MapboxMapController
       // needs to be placed after SymbolManager#addClickListener,
       // is fixed with 0.6.0 of annotations plugin
       mapboxMap.addOnMapClickListener(MapboxMapController.this);
+	  
+	  LocalizationPlugin localizationPlugin = new LocalizationPlugin(mapView, mapboxMap, style);
 
       methodChannel.invokeMethod("map#onStyleLoaded", null);
     }
@@ -393,6 +396,27 @@ final class MapboxMapController
         int myLocationTrackingMode = call.argument("mode");
         setMyLocationTrackingMode(myLocationTrackingMode);
         result.success(null);
+        break;
+      }
+	  case "map#matchMapLanguageWithDeviceDefault": {
+        try {
+		    localizationPlugin.matchMapLanguageWithDeviceDefault();
+			result.success(null);
+		} catch (RuntimeException exception) {
+		    Log.d(TAG, exception.toString());
+			result.error("MAPBOX LOCALIZATION PLUGIN ERROR", exception.toString(), null);
+		}
+        break;
+      }
+	  case "map#setMapLanguage": {
+		final String language = call.argument("language");
+        try {
+		    localizationPlugin.setMapLanguage(language);
+			result.success(null);
+		} catch (RuntimeException exception) {
+		    Log.d(TAG, exception.toString());
+			result.error("MAPBOX LOCALIZATION PLUGIN ERROR", exception.toString(), null);
+		}
         break;
       }
       case "camera#move": {

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -74,6 +74,8 @@ import static com.mapbox.mapboxgl.MapboxMapsPlugin.RESUMED;
 import static com.mapbox.mapboxgl.MapboxMapsPlugin.STARTED;
 import static com.mapbox.mapboxgl.MapboxMapsPlugin.STOPPED;
 
+import com.mapbox.mapboxsdk.plugins.localization.LocalizationPlugin;
+
 /**
  * Controller of a single MapboxMaps MapView instance.
  */
@@ -323,7 +325,7 @@ final class MapboxMapController
       // is fixed with 0.6.0 of annotations plugin
       mapboxMap.addOnMapClickListener(MapboxMapController.this);
 	  
-	  LocalizationPlugin localizationPlugin = new LocalizationPlugin(mapView, mapboxMap, style);
+	  localizationPlugin = new LocalizationPlugin(mapView, mapboxMap, style);
 
       methodChannel.invokeMethod("map#onStyleLoaded", null);
     }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -74,6 +74,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 setMyLocationTrackingMode(myLocationTrackingMode: trackingMode)
             }
             result(nil)
+        case "map#matchMapLanguageWithDeviceDefault":
+            result(nil)
+        case "map#setMapLanguage":
+            result(nil)
         case "camera#move":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let cameraUpdate = arguments["cameraUpdate"] as? [Any] else { return }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -229,6 +229,25 @@ class MapboxMapController extends ChangeNotifier {
       'mode': myLocationTrackingMode.index,
     });
   }
+  
+  /// Updates the language of the map labels to match the device's language.
+  ///
+  /// The returned [Future] completes after the change has been made on the
+  /// platform side.
+  Future<void> matchMapLanguageWithDeviceDefault() async {
+    await _channel.invokeMethod('map#matchMapLanguageWithDeviceDefault');
+  }  
+  
+  /// Updates the language of the map labels to match the specified language.
+  /// Supported language strings are available here: https://github.com/mapbox/mapbox-plugins-android/blob/e29c18d25098eb023a831796ff807e30d8207c36/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java#L39-L87
+  ///
+  /// The returned [Future] completes after the change has been made on the
+  /// platform side.
+  Future<void> setMapLanguage(String language) async {
+    await _channel.invokeMethod('map#matchMapLanguageWithDeviceDefault', <String, dynamic>{
+      'language': language,
+    });
+  }
 
   /// Adds a symbol to the map, configured using the specified custom [options].
   ///

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -244,7 +244,7 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
   Future<void> setMapLanguage(String language) async {
-    await _channel.invokeMethod('map#matchMapLanguageWithDeviceDefault', <String, dynamic>{
+    await _channel.invokeMethod('map#setMapLanguage', <String, dynamic>{
       'language': language,
     });
   }


### PR DESCRIPTION
Copied from [https://github.com/tobrun/flutter-mapbox-gl/pull/146](https://github.com/tobrun/flutter-mapbox-gl/pull/146):
This PR implements the new methods matchMapLanguageWithDeviceDefault() and setMapLanguage(String language) in MapboxMapController
On Android these are implemented through the Mapbox Localization Plugin for Android,
on iOS these function calls are ignored (because I'm unable to correctly implement this for iOS myself, according to this it shouldn't be too much work to implement these two methods on iOS as well, though).